### PR TITLE
Add feature of using string placeholders (%s) instead of the db specific ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ func main() {
 	ctx := context.Background()
 	db, err := ksql.New("sqlite3", "/tmp/hello.sqlite", ksql.Config{
 		MaxOpenConns: 1,
+
+		// UseGolangPlaceholders allows you to use the same placeholder `%s`
+		// for all databases which is useful if you want your code to work in
+		// different platforms.
+		//
+		// Ignore or set this argument to false if you prefer
+		// using the database specific placeholders like `$1`, `?` or `@p1`
+		UseGolangPlaceholders: true,
 	})
 	if err != nil {
 		panic(err.Error())
@@ -186,7 +194,7 @@ func main() {
 
 	// Retrieving Cristina:
 	var cris User
-	err = db.QueryOne(ctx, &cris, "SELECT * FROM users WHERE name = ? ORDER BY id", "Cristina")
+	err = db.QueryOne(ctx, &cris, "SELECT * FROM users WHERE name = %s ORDER BY id", "Cristina")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -234,7 +242,7 @@ func main() {
 	// Making transactions:
 	err = db.Transaction(ctx, func(db ksql.Provider) error {
 		var cris2 User
-		err = db.QueryOne(ctx, &cris2, "SELECT * FROM users WHERE id = ?", cris.ID)
+		err = db.QueryOne(ctx, &cris2, "SELECT * FROM users WHERE id = %s", cris.ID)
 		if err != nil {
 			// This will cause an automatic rollback:
 			return err

--- a/dialect.go
+++ b/dialect.go
@@ -21,6 +21,21 @@ var supportedDialects = map[string]Dialect{
 	"sqlserver": &sqlserverDialect{},
 }
 
+// GetDriverDialect instantiantes the dialect for the
+// provided driver string, if the drive is not supported
+// it returns an error
+func GetDriverDialect(driver string) (Dialect, error) {
+	dialect, found := map[string]Dialect{
+		"postgres": &postgresDialect{},
+		"sqlite3":  &sqlite3Dialect{},
+	}[driver]
+	if !found {
+		return nil, fmt.Errorf("unsupported driver `%s`", driver)
+	}
+
+	return dialect, nil
+}
+
 // Dialect is used to represent the different ways
 // of writing SQL queries used by each SQL driver.
 type Dialect interface {
@@ -64,21 +79,6 @@ func (sqlite3Dialect) Escape(str string) string {
 
 func (sqlite3Dialect) Placeholder(idx int) string {
 	return "?"
-}
-
-// GetDriverDialect instantiantes the dialect for the
-// provided driver string, if the drive is not supported
-// it returns an error
-func GetDriverDialect(driver string) (Dialect, error) {
-	dialect, found := map[string]Dialect{
-		"postgres": &postgresDialect{},
-		"sqlite3":  &sqlite3Dialect{},
-	}[driver]
-	if !found {
-		return nil, fmt.Errorf("unsupported driver `%s`", driver)
-	}
-
-	return dialect, nil
 }
 
 type mysqlDialect struct{}

--- a/examples/crud/crud.go
+++ b/examples/crud/crud.go
@@ -41,6 +41,14 @@ func main() {
 	ctx := context.Background()
 	db, err := ksql.New("sqlite3", "/tmp/hello.sqlite", ksql.Config{
 		MaxOpenConns: 1,
+
+		// UseGolangPlaceholders allows you to use the same placeholder `%s`
+		// for all databases which is useful if you want your code to work in
+		// different platforms.
+		//
+		// Ignore or set this argument to false if you prefer
+		// using the database specific placeholders like `$1`, `?` or `@p1`
+		UseGolangPlaceholders: true,
 	})
 	if err != nil {
 		panic(err.Error())
@@ -91,7 +99,7 @@ func main() {
 
 	// Retrieving Cristina:
 	var cris User
-	err = db.QueryOne(ctx, &cris, "SELECT * FROM users WHERE name = ? ORDER BY id", "Cristina")
+	err = db.QueryOne(ctx, &cris, "SELECT * FROM users WHERE name = %s ORDER BY id", "Cristina")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -139,7 +147,7 @@ func main() {
 	// Making transactions:
 	err = db.Transaction(ctx, func(db ksql.Provider) error {
 		var cris2 User
-		err = db.QueryOne(ctx, &cris2, "SELECT * FROM users WHERE id = ?", cris.ID)
+		err = db.QueryOne(ctx, &cris2, "SELECT * FROM users WHERE id = %s", cris.ID)
 		if err != nil {
 			// This will cause an automatic rollback:
 			return err

--- a/ksql_test.go
+++ b/ksql_test.go
@@ -675,13 +675,14 @@ func TestInsert(t *testing.T) {
 						return
 					}
 
-					ctx := context.Background()
-
 					// Using columns "id" and "name" as IDs:
 					table := NewTable("users", "id", "name")
 
-					c, err := New(config.driver, connectionString[config.driver], Config{})
-					assert.Equal(t, nil, err)
+					db, closer := connectDB(t, config)
+					defer closer.Close()
+
+					ctx := context.Background()
+					c := newTestDB(db, config.driver)
 
 					u := User{
 						Name: "No ID returned",

--- a/placeholder_adapter.go
+++ b/placeholder_adapter.go
@@ -1,0 +1,55 @@
+package ksql
+
+import (
+	"context"
+	"fmt"
+)
+
+type placeholderAdapter struct {
+	Provider
+
+	dialect Dialect
+}
+
+func newPlaceholderAdapter(db Provider, dialect Dialect) placeholderAdapter {
+	return placeholderAdapter{
+		Provider: db,
+		dialect:  dialect,
+	}
+}
+
+func (p placeholderAdapter) Query(ctx context.Context, records interface{}, queryFormat string, params ...interface{}) error {
+	query := fmt.Sprintf(queryFormat, buildPlaceholderList(p.dialect, len(params))...)
+	return p.Provider.Query(ctx, records, query, params...)
+}
+
+func (p placeholderAdapter) QueryOne(ctx context.Context, record interface{}, queryFormat string, params ...interface{}) error {
+	query := fmt.Sprintf(queryFormat, buildPlaceholderList(p.dialect, len(params))...)
+	return p.Provider.QueryOne(ctx, record, query, params...)
+}
+
+func (p placeholderAdapter) QueryChunks(ctx context.Context, parser ChunkParser) error {
+	parser.Query = fmt.Sprintf(parser.Query, buildPlaceholderList(p.dialect, len(parser.Params))...)
+	return p.Provider.QueryChunks(ctx, parser)
+}
+
+func (p placeholderAdapter) Exec(ctx context.Context, queryFormat string, params ...interface{}) error {
+	query := fmt.Sprintf(queryFormat, buildPlaceholderList(p.dialect, len(params))...)
+	return p.Provider.Exec(ctx, query, params...)
+}
+
+func (p placeholderAdapter) Transaction(ctx context.Context, fn func(Provider) error) error {
+	return p.Provider.Transaction(ctx, func(db Provider) error {
+		db = newPlaceholderAdapter(db, p.dialect)
+		return fn(db)
+	})
+}
+
+func buildPlaceholderList(dialect Dialect, numElements int) []interface{} {
+	placeholders := []interface{}{}
+	for i := 0; i < numElements; i++ {
+		placeholders = append(placeholders, dialect.Placeholder(i))
+	}
+
+	return placeholders
+}


### PR DESCRIPTION
With this PR it will now be possible to write cross-database queries with the same placeholder, e.g.:

Instead of querying with:

```golang
switch dbType {
case "sqlite":
    err := db.Query(ctx, "SELECT * FROM foo WHERE id = ?", id)
case "postgres":
    err := db.Query(ctx, "SELECT * FROM foo WHERE id = $1", id)
case "sqlserver":
    err := db.Query(ctx, "SELECT * FROM foo WHERE id = @p1", id)
}
```

You can just use the default formatting placeholder for strings:

```golang
err := db.Query(ctx, "SELECT * FROM foo WHERE id = %s", id)
```