### PR TITLE
Try to fix go modules issue

### DIFF
--- a/adapters/kmysql/go.mod
+++ b/adapters/kmysql/go.mod
@@ -15,10 +15,8 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.1.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/vingarcia/ksql v0.0.0-00010101000000-000000000000
+	github.com/vingarcia/ksql v1.4.2
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )
-
-replace github.com/vingarcia/ksql => ../../

--- a/adapters/kmysql/go.sum
+++ b/adapters/kmysql/go.sum
@@ -151,6 +151,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vingarcia/ksql v1.4.2 h1:kHIrYHdCh9d1ygsDkW19laDhh2FUjVHRcB03Lj+l7r8=
+github.com/vingarcia/ksql v1.4.2/go.mod h1:X9ygN+NPzMyGl6l7xsq9Uob7z6QWBw/7xuCzjfZKEsU=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/adapters/kpgx/go.mod
+++ b/adapters/kpgx/go.mod
@@ -16,8 +16,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.1.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/vingarcia/ksql v0.0.0-00010101000000-000000000000
+	github.com/vingarcia/ksql v1.4.2
 	gotest.tools v2.2.0+incompatible // indirect
 )
-
-replace github.com/vingarcia/ksql => ../../

--- a/adapters/kpgx/go.sum
+++ b/adapters/kpgx/go.sum
@@ -233,6 +233,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vingarcia/ksql v1.4.2 h1:kHIrYHdCh9d1ygsDkW19laDhh2FUjVHRcB03Lj+l7r8=
+github.com/vingarcia/ksql v1.4.2/go.mod h1:X9ygN+NPzMyGl6l7xsq9Uob7z6QWBw/7xuCzjfZKEsU=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/adapters/ksqlite3/go.mod
+++ b/adapters/ksqlite3/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.12
-	github.com/vingarcia/ksql v0.0.0-00010101000000-000000000000
+	github.com/vingarcia/ksql v1.4.2
 )
-
-replace github.com/vingarcia/ksql => ../../

--- a/adapters/ksqlite3/go.sum
+++ b/adapters/ksqlite3/go.sum
@@ -19,6 +19,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/vingarcia/ksql v1.4.2 h1:kHIrYHdCh9d1ygsDkW19laDhh2FUjVHRcB03Lj+l7r8=
+github.com/vingarcia/ksql v1.4.2/go.mod h1:X9ygN+NPzMyGl6l7xsq9Uob7z6QWBw/7xuCzjfZKEsU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/adapters/ksqlserver/go.mod
+++ b/adapters/ksqlserver/go.mod
@@ -15,9 +15,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.1.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/vingarcia/ksql v0.0.0-00010101000000-000000000000
+	github.com/vingarcia/ksql v1.4.2
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )
-
-replace github.com/vingarcia/ksql => ../../

--- a/adapters/ksqlserver/go.sum
+++ b/adapters/ksqlserver/go.sum
@@ -153,6 +153,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vingarcia/ksql v1.4.2 h1:kHIrYHdCh9d1ygsDkW19laDhh2FUjVHRcB03Lj+l7r8=
+github.com/vingarcia/ksql v1.4.2/go.mod h1:X9ygN+NPzMyGl6l7xsq9Uob7z6QWBw/7xuCzjfZKEsU=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
Currently, although all tests are passing the replace directive on the adapters' submodules is breaking `go get` for all adapters.

This is an attempt to fix this issue.