### PR TITLE
Add new API for querying chunks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        #- name: Pull Postgres
-        #  run: docker pull postgres:14.0
-        #- name: Pull MySQL
-        #  run: docker pull mysql:8.0.27
-        #- name: Pull SQLServer
-        #  run: docker pull mcr.microsoft.com/mssql/server:2017-latest
-        #- name: Check go version
-        #  run: go version
-        #- name: Run linters
-        #  run: go vet ./... && go install honnef.co/go/tools/cmd/staticcheck@latest && bash -c "$(go env GOPATH)/bin/staticcheck ./..."
-        #- name: Run Tests
-        #  run: ./scripts/run-all-tests.sh
+      - name: Pull Postgres
+        run: docker pull postgres:14.0
+      - name: Pull MySQL
+        run: docker pull mysql:8.0.27
+      - name: Pull SQLServer
+        run: docker pull mcr.microsoft.com/mssql/server:2017-latest
+      - name: Check go version
+        run: go version
+      - name: Run linters
+        run: go vet ./... && go install honnef.co/go/tools/cmd/staticcheck@latest && bash -c "$(go env GOPATH)/bin/staticcheck ./..."
+      - name: Run Tests
+        run: ./scripts/run-all-tests.sh
       - name: Run Coverage
         run: bash <(curl -s https://codecov.io/bash)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Pull Postgres
-        run: docker pull postgres:14.0
-      - name: Pull MySQL
-        run: docker pull mysql:8.0.27
-      - name: Pull SQLServer
-        run: docker pull mcr.microsoft.com/mssql/server:2017-latest
-      - name: Check go version
-        run: go version
-      - name: Run linters
-        run: go vet ./... && go install honnef.co/go/tools/cmd/staticcheck@latest && bash -c "$(go env GOPATH)/bin/staticcheck ./..."
-      - name: Run Tests
-        run: ./scripts/run-all-tests.sh
+        #- name: Pull Postgres
+        #  run: docker pull postgres:14.0
+        #- name: Pull MySQL
+        #  run: docker pull mysql:8.0.27
+        #- name: Pull SQLServer
+        #  run: docker pull mcr.microsoft.com/mssql/server:2017-latest
+        #- name: Check go version
+        #  run: go version
+        #- name: Run linters
+        #  run: go vet ./... && go install honnef.co/go/tools/cmd/staticcheck@latest && bash -c "$(go env GOPATH)/bin/staticcheck ./..."
+        #- name: Run Tests
+        #  run: ./scripts/run-all-tests.sh
       - name: Run Coverage
         run: bash <(curl -s https://codecov.io/bash)
         env:

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,6 @@ coverage:
   status:
     changes:
       default:
-        threshold: 2%
         # ignore errors from changes, this raises false negatives for
         # code refactors, and I do many refactors, so I don't want this.
-        #if_ci_failed: ignore
+        if_ci_failed: ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,3 @@ coverage:
     project:
       default:
         target: 88%
-        # ignore errors from changes in coverage, this raises false negatives
-        # for code refactors, and I do many refactors, so I don't want this.
-        #if_ci_failed: ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,13 @@
 coverage:
-  precision: 1
   ignore:
     - "internal/**/*"
     - "examples/**/*"
     - "kbuilder/*"
     - "kstructs/*"
+  status:
+    changes:
+      default:
+        threshold: 2%
+        # ignore errors from changes, this raises false negatives for
+        # code refactors, and I do many refactors, so I don't want this.
+        #if_ci_failed: ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,7 @@ coverage:
   status:
     project:
       default:
+        target: 88%
         # ignore errors from changes in coverage, this raises false negatives
         # for code refactors, and I do many refactors, so I don't want this.
-        if_ci_failed: ignore
+        #if_ci_failed: ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 coverage:
+  precision: 1
   ignore:
     - "internal/**/*"
     - "examples/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,8 @@ coverage:
     - "kbuilder/*"
     - "kstructs/*"
   status:
-    changes:
+    project:
       default:
-        # ignore errors from changes, this raises false negatives for
-        # code refactors, and I do many refactors, so I don't want this.
+        # ignore errors from changes in coverage, this raises false negatives
+        # for code refactors, and I do many refactors, so I don't want this.
         if_ci_failed: ignore


### PR DESCRIPTION
## Intro

This is a proposal of change on the ksql API. This change will be 100% retro compatible since it will just add a new function, and deprecate the existing one (which implies removing it from the docs and adding a `// depreacated` comment on it).

The new function is just as safe as the old one but requires an extra error check, which is not ideal, but probably preferable since it still looks better with the error check than the old way of doing it looked like.

## Short description of the QueryChunks feature

The QueryChunks feature is a necessary feature that allows the user to make queries that return very big amounts of data. What this feature does is that instead of loading all the data at once in memory, it loads chunks of the response at a time, which circumvents the problem of overloading the computer's available memory.

## Proposal

This PR is an experimental idea of changing the current API for querying chunks, which looks like this:

```golang
	err = db.QueryChunks(ctx, ksql.ChunkParser{
		Query:     "SELECT * FROM users WHERE type = $1",
		Params:    []interface{}{usersType},
		ChunkSize: 100,
		ForEachChunk: func(users []User) error {
			err := sendUsersSomewhere(users)
			if err != nil {
				// This will abort the QueryChunks loop and return this error
				return err
			}
			return nil
		},
	})
	if err != nil {
		panic(err.Error())
	}
```

To something that looks more natural and easier to read like this:

```golang
	var chunks ksql.Chunks
	err := ksql.Query(ctx, &chunks, `SELECT * FROM users WHERE type = $1`, usersType)
	if err != nil {
		panic(err.Error())
	}

	err := chunks.ForEach(100, func(users []User) error {
		err := sendUsersSomewhere(users)
		if err != nil {
			// This will abort the ForEach loop and return this error
			return err
		}
		return nil
	})
	if err != nil {
		panic(err.Error())
	}
```

In this scenario the `ksql.Query()` function will have a special behavior if the record is passed as an argument is of type `ksql.Chunks`.

This special behavior is to instantiate a new `ksql.chunks{}` struct that has a `.ForEach()` method that behaves just like the existing `ksql.QueryChunks()` function, but requiring less arguments (namely only the `chunkSize` and the for-each callback).

## Possible advantages of this syntax for the future

This syntax could allow us to setup some interesting features such as prepared statements in the future. Since the Query step is done first we could in that step prepare the statement.

This technique could even extend to other types of queries too.

However, if we end up finding a way of implementing a system of creating prepared statements automatically internally this idea might not need to be implemented after all.