### PR TITLE
Check if a field is private after confirming it has a ksql tag

### DIFF
--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -257,15 +257,16 @@ func getTagNames(t reflect.Type) (_ StructInfo, err error) {
 		byName:  map[string]*FieldInfo{},
 	}
 	for i := 0; i < t.NumField(); i++ {
-		// If this field is private:
-		if t.Field(i).PkgPath != "" {
-			return StructInfo{}, fmt.Errorf("all fields using the ksql tags must be exported, but %v is unexported", t)
-		}
 
 		attrName := t.Field(i).Name
 		name := t.Field(i).Tag.Get("ksql")
 		if name == "" {
 			continue
+		}
+
+		// If this field is private:
+		if t.Field(i).PkgPath != "" {
+			return StructInfo{}, fmt.Errorf("all fields using the ksql tags must be exported, but %v is unexported", t)
 		}
 
 		tags := strings.Split(name, ",")


### PR DESCRIPTION
This fixes a bug. The current code triggers the fixed error when a private field, without a ksql tag, is present in the struct.