### PR TITLE
feat: add Name accessor method to Table struct

### DIFF
--- a/contracts.go
+++ b/contracts.go
@@ -107,6 +107,10 @@ func (t Table) validate() error {
 	return nil
 }
 
+func (t Table) Name() string {
+	return t.name
+}
+
 func (t Table) insertMethodFor(dialect sqldialect.Provider) sqldialect.InsertMethod {
 	if len(t.idColumns) == 1 {
 		return dialect.InsertMethod()


### PR DESCRIPTION
This is really minor but it helps me to avoid having to type the table name multiple times in the code ;-)

I opted to add a method so that the real table name stays immutable for callers.